### PR TITLE
Add init-project workflow scaffold (PRD, ADRs, glossary, M1 plan)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "enabledPlugins": {
+    "init-project@claude-project-workflow": true,
+    "exec-tasks@claude-project-workflow": true,
+    "post-session@claude-project-workflow": true
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "swift build 2>&1 | tail -40"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ tests/visual_report.html
 # Local scratch (screenshots, etc.)
 tmp/
 tmp-*/
+
+# init-project / exec-tasks workflow (stripped at M3 — see ADR-0003)
+.init-project-state.json
+.claude/settings.local.json
+.memory/work/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,3 +275,44 @@ Notes:
 - README download button points to `releases/latest/download/cmux-macos.dmg`.
 - Versioning: bump the minor version for updates unless explicitly asked otherwise.
 - Changelog: update `CHANGELOG.md`; docs changelog is rendered from it.
+
+---
+
+## Project: iOS Simulator Surface (this fork's overlay)
+
+This repository (`yuchida-tamu/cmux-with-ios-simulator`) is a fork of `manaflow-ai/cmux` whose purpose is to add a `SurfaceType.simulator` — a cmux pane that hosts a live iOS Simulator framebuffer rendered via `IOSurface` → `CAMetalLayer`.
+
+End-state is an upstream PR back to `manaflow-ai/cmux` (see [ADR-0002](docs/adr/0002-fork-then-upstream-pr.md) for the contribution model and [ADR-0003](docs/adr/0003-graft-workflow-scaffold-on-fork.md) for why the workflow scaffold lives in-tree on this fork). Everything above this `---` is upstream cmux's `CLAUDE.md`, untouched. Everything below is this project's overlay and is **stripped before the upstream PR by `scripts/upstream-pr-prep.sh`** (per ADR-0003 §"M3 cleanup script").
+
+### Project pointers
+
+- **Project goal & scope:** [`docs/PRD.md`](docs/PRD.md)
+- **Domain vocabulary:** [`docs/glossary.md`](docs/glossary.md)
+- **Architecture decisions:** [`docs/adr/`](docs/adr/) — start with [ADR-0002 "Fork-then-upstream-PR"](docs/adr/0002-fork-then-upstream-pr.md) and [ADR-0003 "Graft workflow scaffold on the fork"](docs/adr/0003-graft-workflow-scaffold-on-fork.md)
+- **Per-task plans:** [`.memory/plans/`](.memory/plans/) (populated by `exec-tasks`)
+- **Spike write-ups:** `docs/spikes/NN-<slug>.md` (one per Spike issue in M1)
+- **Issue tracker / project board:** GitHub issues on this fork. Milestones `M1`/`M2`/`M3`, labels `P0`–`P3` and `type:feature`/`bug`/`chore`/`docs`.
+
+### Project principles (apply on top of upstream cmux's principles above)
+
+- **Match upstream cmux style first.** Before adding a new file or pattern, check how cmux already does it (`Sources/Panels/`, the `Panel` protocol, `CmuxConfig`). Don't introduce new abstractions if a cmux convention already exists — it has to land in upstream.
+- **Private Apple SPI lives behind one boundary.** All `CoreSimulator` / `FBSimulatorControl` private-header usage is confined to a single Swift module (`Sources/SimulatorKit/`) so it can be feature-flagged off, swapped to public APIs if Apple ever ships them, or mocked in tests.
+- **Spike write-ups in `docs/spikes/NN-<slug>.md`.** Each Spike issue lands a markdown file with: what we tried, what worked, what code refs to copy forward, what to throw away.
+- **Never link Apple private frameworks in CI artifacts that get distributed.** Private SPI is for local dev only; CI builds for distribution must stay clean for the eventual upstream PR.
+- **Fork-then-upstream-PR.** Every architectural choice must be defensible to a Manaflow maintainer at PR-review time. When upstream cmux disagrees with our preference, upstream wins. See [ADR-0002](docs/adr/0002-fork-then-upstream-pr.md).
+- **Cleanup discipline (ADR-0003).** Adding a workflow-scaffold file that the M3 cleanup script can't reverse is a contract violation. Either extend the script or don't add the file.
+
+### Project commands
+
+- **Project check (pre-PR, must pass):** upstream cmux's command — `xcodebuild -project GhosttyTabs.xcodeproj test` (or whatever upstream uses; defer to cmux's existing CI).
+- **PostToolUse hook (fast feedback during edits):** `swift build` — this is intentionally lighter than the pre-PR check so the hook stays responsive. Configured in `.claude/settings.json`. Comment out or downgrade if it becomes painful in `Sources/SimulatorKit/`.
+
+### Project workflow
+
+1. Branch from `main` of this fork.
+2. Read `docs/PRD.md`, the relevant ADR(s), and any matching `.memory/plans/<issue>-plan.md`.
+3. Implement.
+4. Run upstream cmux's check command (must pass).
+5. Push branch, open PR against this fork's `main` — `@claude` PR review fires here.
+6. On merge, sync `main` and delete the local branch.
+7. **At M3:** run `scripts/upstream-pr-prep.sh` to strip the workflow scaffold, then open the upstream PR against `manaflow-ai/cmux:main`.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,51 @@
+# cmux-with-ios-simulator — PRD
+
+## Overview
+
+A `SurfaceType.simulator` for cmux that renders a headless iOS Simulator framebuffer (`IOSurface` → `CAMetalLayer`) directly inside a cmux pane, alongside the existing terminal/browser/markdown surfaces. Built for cmux users who want native, low-latency iOS dev workflows without a separate `Simulator.app` window. Prototyped on this fork of `manaflow-ai/cmux`; the feature targets an upstream PR at M3 (see [ADR-0002](./adr/0002-fork-then-upstream-pr.md)). Workflow scaffolding (PRD, ADRs, etc.) lives in-tree on this fork and is removed before the upstream PR (see [ADR-0003](./adr/0003-graft-workflow-scaffold-on-fork.md)).
+
+## Goals
+
+- Boot and drive a headless `SimDevice` from cmux without spawning `Simulator.app`.
+- Render the simulator framebuffer into a Metal-backed cmux pane at 60fps with no JPEG/HTTP indirection.
+- Forward mouse, keyboard, and (eventually) multitouch + hardware buttons (Home, AppSwitcher) into the simulator.
+- Land the feature upstream in `manaflow-ai/cmux` as `SurfaceType.simulator` (M3).
+
+## Non-Goals
+
+- Not a re-implementation of `Simulator.app`. We do not aim to replace Xcode's simulator UI for general developers.
+- Not a cross-platform tool. macOS only — no Linux/Windows builds, no Android emulator support (Radon's Android path is out of scope).
+- Not a JPEG/HTTP streaming pipeline. We explicitly skip Radon's MJPEG indirection because cmux is native.
+- Not a public/stable API surface. We rely on Apple private headers (`CoreSimulator`, `FBSimulatorControl`) and may break with Xcode updates.
+- Not a standalone product. Only ships as a feature of cmux; no separate distribution.
+
+## Users
+
+Existing cmux users who develop iOS apps. They already use cmux for terminal/browser/markdown panes; they want a simulator pane that fits the same pane/surface model rather than alt-tabbing to `Simulator.app`.
+
+## Core Loop
+
+User opens a cmux pane with `cmux new-pane --type simulator --device 'iPhone 15 Pro'`, sees the live booted iOS Simulator framebuffer rendered into the pane, and interacts with it via mouse/keyboard/multitouch the same way they'd use any other cmux surface — alongside their terminal, browser, and markdown panes.
+
+## Milestones
+
+- **M1 (MVP — validate the pipeline):** Option A working. `sim-server` Swift daemon links `FBSimulatorControl`, exposes `IOSurface` over Unix socket; `simulator` panel renders one device's framebuffer; mouse/keyboard input forwarded; manual `cmux new-pane --type simulator --device 'iPhone 15 Pro'` works end-to-end.
+- **M2 (Polish — collapse to in-process):** Move `CoreSimulator` linkage in-process (Option B). Graceful `CoreSimulatorService` death recovery, multitouch + hardware buttons (Home/AppSwitcher), Xcode version sniffing, no-cmux integration test harness.
+- **M3 (Ship — upstream):** Open upstream feature-request issue, address maintainer feedback, sign Manaflow CLA, run the workflow-scaffold cleanup script (ADR-0003), land PR into `manaflow-ai/cmux` so `SurfaceType.simulator` exists in mainline.
+
+## Open Questions
+
+- **Riskiest unknown:** Apple private SPI (`CoreSimulator`, `FBSimulatorControl`, `SimDisplayIOSurfaceRenderable`) breaking or being walled off in an Xcode update — the entire pipeline depends on it. Secondary: `IOSurface` IPC across the daemon ↔ cmux process boundary hitting sandbox/entitlement walls in Option A. Tertiary: codesigning / hardened-runtime rejecting linkage against private frameworks at distribution time.
+- **Upstream signal:** No existing maintainer signal for a `simulator` surface. Issue #2770 in `manaflow-ai/cmux` is unrelated (CLI pane-reuse ergonomics). Whether maintainers will accept the upstream PR is unproven; record the upstream issue URL here once filed (M3).
+- **Xcode version coverage:** Which Xcode versions must the SPI shim support? Initial target: latest stable + previous minor. Decide at M2.
+- **Hook responsiveness:** PostToolUse hook runs `swift build`. If incremental builds become painful as `Sources/SimulatorKit/` grows, downgrade to `swift build --target SimulatorKit` or comment out the hook entirely. Decide at M2 review.
+
+## Reference material
+
+- cmux: <https://github.com/manaflow-ai/cmux>
+- cmux feature request — pane-typed surfaces (CLI ergonomics, not surface API): <https://github.com/manaflow-ai/cmux/issues/2770>
+- Radon IDE: <https://github.com/software-mansion/radon-ide>
+- Radon IDE — pane mode docs: <https://ide.swmansion.com/docs/getting-started/panel-mode>
+- idb (`FBSimulatorControl` source): <https://github.com/facebook/idb> (`fbsimctl/FBSimulatorControl/`)
+- idb private CoreSimulator overview: <https://fbidb.io/docs/coresimulator/>
+- Public Radon `sim-server` MJPEG architecture (prior art): Radon IDE issues #2770, #528, #645

--- a/docs/adr/0001-record-architecture-decisions-in-adrs.md
+++ b/docs/adr/0001-record-architecture-decisions-in-adrs.md
@@ -1,0 +1,21 @@
+# 1. Record architecture decisions in ADRs
+
+Date: 2026-04-26
+
+## Status
+
+Accepted
+
+## Context
+
+We need a lightweight, version-controlled way to record significant architectural decisions so future contributors (human or agent) can understand the reasoning behind the current shape of the codebase.
+
+## Decision
+
+We will record architecture decisions here using the ADR format (Markdown Architectural Decision Records). Each ADR lives in `docs/adr/` and is numbered sequentially.
+
+## Consequences
+
+- Every non-obvious architectural decision gets a short written rationale.
+- Agents and reviewers can grep `docs/adr/` before proposing divergent patterns.
+- New decisions require a new ADR; supersessions are recorded explicitly.

--- a/docs/adr/0002-fork-then-upstream-pr.md
+++ b/docs/adr/0002-fork-then-upstream-pr.md
@@ -1,0 +1,41 @@
+# 2. Fork-then-upstream-PR — never permanent fork
+
+Date: 2026-04-26
+
+## Status
+
+Accepted
+
+## Context
+
+cmux (`manaflow-ai/cmux`) is a native Swift/AppKit application. Inspection of `Sources/Panels/Panel.swift` shows `enum PanelType { terminal, browser, markdown }` — a closed Swift enum — and a `@MainActor` `internal` `Panel` protocol. A mirror `enum CmuxSurfaceType` lives in `Sources/CmuxConfig.swift`. There is **no plugin/extension API**: no surface registry, no dylib loading, no JS scripting hook, no `plugins/` directory. The closest precedent (`AppIconDockTilePlugin.swift`) is an `NSDockTilePlugIn`, unrelated to surface types.
+
+Adding a `SurfaceType.simulator` therefore requires editing the closed enum, the surface-type mirror, the `PanelContentView` SwiftUI dispatcher, the CLI argument parser, and the config schema — all in-tree changes to upstream cmux.
+
+cmux is licensed GPL-3.0-or-later with a dual commercial license; `CONTRIBUTING.md` requires a CLA-like grant to Manaflow that allows commercial relicensing of contributions. The codebase is friendly to additive panel work because the `Panel` protocol cleanly abstracts panel behavior. There is no upstream issue requesting an iOS Simulator surface today (issue #2770 is unrelated CLI ergonomics work).
+
+We considered three options:
+
+1. **Permanent fork** — minimum upfront friction, maximum maintenance cost (must rebase against every upstream change indefinitely).
+2. **Plugin/extension** — impossible: no extension API exists, and adding one is itself an upstream change requiring maintainer buy-in.
+3. **Fork-then-upstream-PR** — prototype on a fork, propose the merged feature back to upstream. Slightly higher coordination cost (file an issue first, sign the CLA, follow upstream conventions), but the only path that yields a stable shipping artifact without forever rebasing.
+
+## Decision
+
+We will use the fork-then-upstream-PR model. Concretely:
+
+- This repository (`yuchida-tamu/cmux-with-ios-simulator`) is a fork of `manaflow-ai/cmux` and is treated as a **prototype branch**, not a long-lived product.
+- All architectural choices made in this fork must be defensible against upstream maintainers. When a decision could go two ways, prefer the option closer to upstream conventions (`Panel` protocol shape, file layout under `Sources/Panels/`, naming consistent with `terminal` / `browser` / `markdown`).
+- New abstractions are added only when an upstream review would also accept them. No "internal-only" patterns that would have to be redone before the PR.
+- Spike code that is not upstream-quality lives in clearly marked locations (e.g., `docs/spikes/`, separate non-merged branches) and is not allowed to leak into mainline directories.
+- The workflow scaffold itself (`docs/PRD.md`, `docs/adr/`, `docs/glossary.md`, `.memory/`, project-overlay section in `CLAUDE.md`, `.claude/settings.json`) is project coordination state. It is NOT shipped to upstream — see [ADR-0003](./0003-graft-workflow-scaffold-on-fork.md) for the cleanup contract.
+- M3 is "land an upstream PR." Until then, M1 and M2 are explicitly graded against the question: "Could this be reviewed by a Manaflow maintainer without major rework?"
+
+## Consequences
+
+- **Single source of truth on style.** When upstream cmux disagrees with our preference, upstream wins. We follow `Sources/Panels/Panel.swift` conventions even when ours feel cleaner, because the cost of arguing the change in PR review exceeds the local ergonomics gain.
+- **Apple private SPI is firewalled.** All `CoreSimulator` / `FBSimulatorControl` / `IOSurface` private-header usage lives behind a single Swift module boundary (e.g., `Sources/SimulatorKit/`) so it can be feature-flagged off, swapped to a public API if Apple ever ships one, or stripped from the upstream PR if maintainers ask.
+- **No cmux-core rewrites.** A change is only proposed if the same value couldn't be obtained additively. Refactors of unrelated panel code are out of scope.
+- **Upstream feature-request issue is mandatory.** Before merging into the fork's `main`, an upstream issue describing the design (Option A → Option B), prior art (Radon IDE), and license/CLA acknowledgement is filed in `manaflow-ai/cmux`. The issue URL is recorded in `docs/PRD.md` under "Open Questions."
+- **CI artifacts must stay clean.** Distributable builds may not link Apple private frameworks. Private SPI is local-dev only until M3 lands and maintainers decide how to gate it (compile flag, separate target, etc.).
+- **Maintenance burden is bounded.** If upstream rejects the PR at M3, this ADR is superseded by an explicit "permanent fork" ADR with revised milestones; we do not silently drift into a permanent fork.

--- a/docs/adr/0003-graft-workflow-scaffold-on-fork.md
+++ b/docs/adr/0003-graft-workflow-scaffold-on-fork.md
@@ -1,0 +1,73 @@
+# 3. Graft workflow scaffold onto the fork (single repo)
+
+Date: 2026-04-26
+
+## Status
+
+Accepted (final — supersedes two earlier oscillations between this design and a meta-repo split)
+
+## Context
+
+This project produces two kinds of artifact:
+
+1. **Project-coordination state** — PRD, ADRs, glossary, spike write-ups, per-task plans, GitHub issues, project board.
+2. **Swift/Obj-C++ code changes** — additions to the cmux source tree (`Sources/Panels/`, `CmuxConfig`, `CLI/`, plus a new `Sources/SimulatorKit/`).
+
+Two layouts are technically viable:
+
+- **A. Two repos.** A meta repo holds (1); a separate fork of `manaflow-ai/cmux` holds (2). Issues live in the meta repo; PRs live in the fork.
+- **B. One repo (graft).** One fork of `manaflow-ai/cmux`. Workflow scaffold sits next to the cmux source under `docs/`, `.memory/`, `CLAUDE.md` overlay, etc. Issues AND PRs live on the same repo.
+
+We attempted A (meta repo) and reverted. We attempted B (graft) and reverted. We are now choosing B again, this time deliberately — and recording the reasoning so we don't oscillate again.
+
+### Why B (graft) wins
+
+1. **`@claude` PR review fires in the right place.** Claude Code's GitHub workflow (`.github/workflows/claude.yml`) is enabled per-repo and reviews PRs on that repo. With layout B, code PRs and `@claude` review live together. With layout A, the meta repo's `@claude` install is wasted (no code PRs there) and the fork repo needs its own install — fragmenting setup, secrets, and review history.
+2. **One git history per change.** A spike write-up under `docs/spikes/03-iosurface-metal.md` and the Swift code it describes land in the same PR. Bisecting, blaming, and code review all see one diff. Layout A forces a cross-repo dance: open meta-repo issue → write fork-repo PR → write meta-repo PR for the spike doc → cross-link the three.
+3. **Single working directory.** No "did you `cd` into the right repo" foot-gun. `exec-tasks` agents read the issue, the plan, and edit the code in one checkout.
+4. **Simpler permissions and secrets.** One install of the GitHub App, one `CLAUDE_CODE_OAUTH_TOKEN`, one set of Actions secrets.
+
+### Cost of B that A would have avoided
+
+- The eventual upstream PR at M3 contains workflow-scaffold files (`docs/PRD.md`, `docs/adr/0001..0003`, `docs/glossary.md`, `.memory/`, the project-overlay section in `CLAUDE.md`, `.claude/settings.json` enabledPlugins, the workflow-only `.gitignore` lines) that upstream cmux maintainers don't want. We pay this cost as a **scripted cleanup step** in the M3 PR-prep flow, not as ongoing friction.
+- PRD/ADR edits live alongside a large source tree (Swift, Ghostty submodule, marketing site). A bit noisier in the file tree, but cheap enough.
+
+## Decision
+
+We use layout B: a single fork of `manaflow-ai/cmux` with the workflow scaffold grafted on top. Concretely:
+
+- **Repo:** `yuchida-tamu/cmux-with-ios-simulator` (fork of `manaflow-ai/cmux`).
+- **Workflow-scaffold files in this fork** (the set that must be removed before the upstream PR):
+  - `docs/PRD.md`
+  - `docs/glossary.md`
+  - `docs/adr/0001-record-architecture-decisions-in-adrs.md`
+  - `docs/adr/0002-fork-then-upstream-pr.md`
+  - `docs/adr/0003-graft-workflow-scaffold-on-fork.md` (this file)
+  - `docs/spikes/` (entire directory)
+  - `.memory/` (entire directory)
+  - `.claude/settings.json` (only our additions — the `enabledPlugins` block; preserve any upstream additions)
+  - The "Project: iOS Simulator Surface (this fork's overlay)" section appended to `CLAUDE.md` (and to the symlinked `AGENTS.md` it shadows)
+  - The workflow-only block appended to `.gitignore` (`.init-project-state.json`, `.claude/settings.local.json`, `.memory/work/`)
+- **Files we do NOT add or overwrite** (upstream owns them): `LICENSE` (GPL-3.0), `README.*`, `.github/workflows/claude.yml`, `.github/workflows/ci.yml`, `.github/workflows/*` in general. We rely on upstream's CI for the project check.
+- **PostToolUse hook.** `.claude/settings.json` enables a `swift build` hook on `Edit|Write|MultiEdit` — fast subset of upstream's `xcodebuild test` check. Configurable: comment out or downgrade if it becomes painful (see PRD Open Questions).
+
+### M3 cleanup script
+
+Before the upstream PR is opened, the cleanup script (TBD: lives at `scripts/upstream-pr-prep.sh`, written when first needed) MUST:
+
+1. Delete all paths in the "Workflow-scaffold files" list above.
+2. Strip the project-overlay section from `CLAUDE.md` (everything below the `## Project: iOS Simulator Surface (this fork's overlay)` heading).
+3. Strip the workflow-only `.gitignore` block.
+4. Open a clean PR branch from the fork's `main` containing ONLY the cmux source changes.
+5. Verify with `git diff manaflow-ai/cmux/main` that nothing scaffold-related remains.
+
+The script is the contract. If it can't cleanly strip a file, that file shouldn't be added under workflow scaffolding in the first place.
+
+## Consequences
+
+- **Workflow plugins stay enabled in this repo.** `.claude/settings.json` lists `init-project`, `exec-tasks`, `post-session`. Anyone who clones the fork and opens it in Claude Code gets the workflow on first run.
+- **`@claude` PR review available everywhere PRs happen.** Both feature-branch PRs against this fork's `main` and the eventual upstream PR (after cleanup) are reviewable by Claude in this single repo configuration.
+- **No cross-repo bookkeeping.** Issues and code PRs share a tracker. Spike write-ups, plans, and code share one git history.
+- **Cleanup discipline is mandatory.** Adding a workflow-scaffold file that the cleanup script can't reverse is a contract violation. Either extend the script or don't add the file.
+- **Upstream PR diff stays clean.** When M3 opens, the diff against `manaflow-ai/cmux:main` contains only cmux source changes — no PRD, no ADRs, no `.memory/` artifacts, no project-overlay text in `CLAUDE.md`.
+- **Meta-repo split remains an emergency option.** If the cleanup script becomes unmaintainable, we can split out the workflow scaffold into a separate meta repo and revisit. ADR-0003 is superseded only by an explicit replacement ADR — not by silent drift.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,8 @@
+# Glossary
+
+- **`SurfaceType.simulator`** — A new pane/surface variant in cmux (peer of `terminal` / `browser` / `markdown`) that hosts a live iOS Simulator framebuffer, rendered into a `CAMetalLayer`-backed `NSView` and driven by a headless `SimDevice`. The artifact this project delivers.
+- **Headless `SimDevice`** — A booted iOS Simulator instance that does NOT spawn `Simulator.app`. Created via `CoreSimulator`'s `SimDeviceSet` at a custom path, owned by our daemon (Option A) or the cmux process (Option B). Same mechanism `idb` and Facebook's `FBSimulatorControl` use.
+- **`IOSurface` framebuffer** — GPU-shareable opaque buffer that holds a single rendered Simulator frame. Exposed by `SimDisplayIOSurfaceRenderable` private SPI; cheap to share across processes/threads without a JPEG/HTTP round-trip. The reason this project can skip Radon's MJPEG indirection.
+- **`sim-server` (Option A)** — Out-of-process Swift/Obj-C++ daemon that links `FBSimulatorControl`, owns the headless `SimDevice`, and exposes `IOSurface` IDs + JSON-RPC input over a Unix socket. Prototype-stage only; collapsed into cmux at M2 (Option B).
+- **Fork-then-upstream-PR** — The project's contribution model (see [ADR-0002](./adr/0002-fork-then-upstream-pr.md)). All changes prototyped on this fork of `manaflow-ai/cmux` are eventually proposed back as a PR; the fork is not the shipping artifact.
+- **Workflow scaffold** — Files in this fork that exist to coordinate the project (PRD, ADRs, glossary, `.memory/`, the project-overlay section in `CLAUDE.md`, the workflow-plugin enablement in `.claude/settings.json`). Removed before the upstream PR per ADR-0003. Not shipped to upstream cmux.


### PR DESCRIPTION
Grafted onto manaflow-ai/cmux fork to coordinate the SurfaceType.simulator prototype, with @claude PR review and code changes living in this single repo (see ADR-0003 for the layout rationale and the M3 cleanup contract).

ADR-0001 introduces ADRs. ADR-0002 commits us to fork-then-upstream-PR (never a permanent fork). ADR-0003 documents why the workflow scaffold lives in-tree on this fork and lists the files that must be stripped before the upstream PR. Hooks: PostToolUse runs `swift build` for fast edit-time feedback; full xcodebuild test stays the pre-PR check.

Upstream cmux files (LICENSE, README, CI workflows, claude.yml) untouched.

## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved
